### PR TITLE
support peer dependency manifest fields and preserve unknown fields

### DIFF
--- a/apps/api/__tests__/mocks/package-publish-payload.json
+++ b/apps/api/__tests__/mocks/package-publish-payload.json
@@ -13,6 +13,15 @@
 			"scripts": {
 				"test": "echo \"Error: no test specified\" && exit 1"
 			},
+			"peerDependencies": {
+				"react": "^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				}
+			},
+			"license": "MIT",
 			"_nodeVersion": "21.6.0",
 			"_npmVersion": "10.2.4",
 			"dist": {

--- a/apps/api/src/routers/package/validators.ts
+++ b/apps/api/src/routers/package/validators.ts
@@ -30,7 +30,7 @@ export const validators = {
 				"dist-tags": z.record(z.string(), z.string()),
 				versions: z.record(
 					z.string().regex(semverRegex(), { message: "Version is not in semver format" }),
-					z.object({
+					z.looseObject({
 						_id: z.string().min(1),
 						name: z.string().min(1),
 						type: z.string().optional(),
@@ -39,6 +39,15 @@ export const validators = {
 						scripts: z.record(z.string(), z.string()).optional(),
 						devDependencies: z.record(z.string(), z.string()).optional(),
 						dependencies: z.record(z.string(), z.string()).optional(),
+						peerDependencies: z.record(z.string(), z.string()).optional(),
+						peerDependenciesMeta: z
+							.record(
+								z.string(),
+								z.looseObject({
+									optional: z.boolean().optional()
+								})
+							)
+							.optional(),
 						_nodeVersion: z.string().optional(),
 						_npmVersion: z.string().optional(),
 						dist: z.object({


### PR DESCRIPTION
Hi! I noticed that my package, which has `peerDependencies` set, doesn't properly show them once I run `npm view`.

It turns out that `peerDependencies` is not part of the Zod schema for a package publish, and that Zod was then stripping it out from the persisted package metadata.

This changes this in two ways: It adds `peerDependencies` to the valid Zod fields, and also specifies [`z.looseObject()`](https://zod.dev/api#zlooseobject) so Zod **doesn't strip unknown fields**.
