### PR TITLE
feat: add SQL defaults for timestamp columns

### DIFF
--- a/apps/api/migrations/0001_tiny_apocalypse.sql
+++ b/apps/api/migrations/0001_tiny_apocalypse.sql
@@ -1,0 +1,36 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_package_release` (
+	`package` text NOT NULL,
+	`version` text NOT NULL,
+	`tag` text NOT NULL,
+	`manifest` text NOT NULL,
+	`created_at` integer DEFAULT (unixepoch('subsec') * 1000) NOT NULL,
+	PRIMARY KEY(`package`, `version`),
+	FOREIGN KEY (`package`) REFERENCES `package`(`name`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_package_release`("package", "version", "tag", "manifest", "created_at") SELECT "package", "version", "tag", "manifest", "created_at" FROM `package_release`;--> statement-breakpoint
+DROP TABLE `package_release`;--> statement-breakpoint
+ALTER TABLE `__new_package_release` RENAME TO `package_release`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE TABLE `__new_package` (
+	`name` text PRIMARY KEY NOT NULL,
+	`dist_tags` text NOT NULL,
+	`created_at` integer DEFAULT (unixepoch('subsec') * 1000) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch('subsec') * 1000) NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_package`("name", "dist_tags", "created_at", "updated_at") SELECT "name", "dist_tags", "created_at", "updated_at" FROM `package`;--> statement-breakpoint
+DROP TABLE `package`;--> statement-breakpoint
+ALTER TABLE `__new_package` RENAME TO `package`;--> statement-breakpoint
+CREATE TABLE `__new_token` (
+	`token` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`scopes` text NOT NULL,
+	`created_at` integer DEFAULT (unixepoch('subsec') * 1000) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch('subsec') * 1000) NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_token`("token", "name", "scopes", "created_at", "updated_at") SELECT "token", "name", "scopes", "created_at", "updated_at" FROM `token`;--> statement-breakpoint
+DROP TABLE `token`;--> statement-breakpoint
+ALTER TABLE `__new_token` RENAME TO `token`;

--- a/apps/api/migrations/meta/0001_snapshot.json
+++ b/apps/api/migrations/meta/0001_snapshot.json
@@ -1,0 +1,166 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "42aa3359-d96c-446a-87ff-5c8f26a4bce1",
+	"prevId": "8c29bf40-bd6d-41e5-9eb6-cc8255b60e6a",
+	"tables": {
+		"package_release": {
+			"name": "package_release",
+			"columns": {
+				"package": {
+					"name": "package",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"version": {
+					"name": "version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tag": {
+					"name": "tag",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"manifest": {
+					"name": "manifest",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(unixepoch('subsec') * 1000)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"package_release_package_package_name_fk": {
+					"name": "package_release_package_package_name_fk",
+					"tableFrom": "package_release",
+					"tableTo": "package",
+					"columnsFrom": ["package"],
+					"columnsTo": ["name"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"package_release_package_version_pk": {
+					"columns": ["package", "version"],
+					"name": "package_release_package_version_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"package": {
+			"name": "package",
+			"columns": {
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"dist_tags": {
+					"name": "dist_tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(unixepoch('subsec') * 1000)"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(unixepoch('subsec') * 1000)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"token": {
+			"name": "token",
+			"columns": {
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(unixepoch('subsec') * 1000)"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(unixepoch('subsec') * 1000)"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/apps/api/migrations/meta/_journal.json
+++ b/apps/api/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
 			"when": 1733059981509,
 			"tag": "0000_bright_mercury",
 			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "6",
+			"when": 1787066041706,
+			"tag": "0001_tiny_apocalypse",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,18 +1,21 @@
+import { sql } from "drizzle-orm";
 import { integer, primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+const unixEpochMs = sql`(unixepoch('subsec') * 1000)`;
 
 export const tokenTable = sqliteTable("token", {
 	token: text("token").primaryKey().notNull(),
 	name: text("name").notNull(),
 	scopes: text("scopes", { mode: "json" }).notNull().$type<Array<{ type: string; values: Array<string> }>>(),
-	createdAt: integer("created_at").notNull(),
-	updatedAt: integer("updated_at").notNull()
+	createdAt: integer("created_at").notNull().default(unixEpochMs),
+	updatedAt: integer("updated_at").notNull().default(unixEpochMs)
 });
 
 export const packageTable = sqliteTable("package", {
 	name: text("name").primaryKey().notNull(),
 	distTags: text("dist_tags", { mode: "json" }).notNull().$type<Record<string, string>>(),
-	createdAt: integer("created_at").notNull(),
-	updatedAt: integer("updated_at").notNull()
+	createdAt: integer("created_at").notNull().default(unixEpochMs),
+	updatedAt: integer("updated_at").notNull().default(unixEpochMs)
 });
 
 export const packageReleaseTable = sqliteTable(
@@ -24,7 +27,7 @@ export const packageReleaseTable = sqliteTable(
 		version: text("version").notNull(),
 		tag: text("tag").notNull(),
 		manifest: text("manifest", { mode: "json" }).notNull(),
-		createdAt: integer("created_at").notNull()
+		createdAt: integer("created_at").notNull().default(unixEpochMs)
 	},
 	(table) => [primaryKey({ columns: [table.package, table.version] })]
 );


### PR DESCRIPTION
Hi! This change makes a small ergonomic change, and it's also totally fine if you reject it.

Rather than issuing new tokens using the token API, it might be easier for us to just add them to D1 directly, using D1's only query interface.

That's possible already, but one stumbling stone is that you manually have to enter a ms-precision UNIX timestamp.

This makes this a bit easier, by marking all timestamp fields with a DEFAULT value.

Again, totally fine if you reject this change because you don't want it.